### PR TITLE
solution 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,4 +47,4 @@ Implement the ability to edit a todo title on double click:
 
 - Implement a solution following the [React task guideline](https://github.com/mate-academy/react_task-guideline#react-tasks-guideline).
 - Use the [React TypeScript cheat sheet](https://mate-academy.github.io/fe-program/js/extra/react-typescript).
-- Replace `<your_account>` with your Github username in the [DEMO LINK](https://<your_account>.github.io/react_todo-app-with-api/) and add it to the PR description.
+- Replace `<your_account>` with your Github username in the [DEMO LINK](https://akryto.github.io/react_todo-app-with-api/) and add it to the PR description.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,26 +1,266 @@
-/* eslint-disable max-len */
+/* eslint-disable jsx-a11y/label-has-associated-control */
 /* eslint-disable jsx-a11y/control-has-associated-label */
-import React from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { UserWarning } from './UserWarning';
-
-const USER_ID = 0;
+import {
+  USER_ID,
+  createTodo,
+  deleteTodo,
+  getTodos,
+  patchTodo,
+} from './api/todos';
+import { List } from './components/List';
+import { Error as ErrorMessage } from './components/Error';
+import { Footer } from './components/Footer';
+import { Header } from './components/Header';
+import { Todo } from './types/Todo';
+import { Filter } from './types/Filter';
 
 export const App: React.FC = () => {
+  const [todos, setTodos] = useState<Todo[]>([]);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [filter, setFilter] = useState(Filter.All);
+  const [tempTodoTitle, setTempTodoTitle] = useState<string | null>('');
+  const [idsProccesing, setIdsProccesing] = useState<number[]>([]);
+
+  const ref = useRef<HTMLInputElement | null>(null);
+
+  const handleAddTodo = async (title: string) => {
+    const formattedTitle = title.trim();
+
+    if (!formattedTitle) {
+      setErrorMessage('Title should not be empty');
+
+      return;
+    }
+
+    const newTodo = {
+      title: formattedTitle,
+      completed: false,
+      userId: USER_ID,
+    };
+
+    try {
+      setTempTodoTitle(title); // Show the temporary todo
+
+      const createdTodo = await createTodo(newTodo);
+
+      setTodos(currentTodos => [...currentTodos, createdTodo]);
+    } catch {
+      setErrorMessage('Unable to add a todo');
+      throw new Error('Unable to add a todo');
+    } finally {
+      setTempTodoTitle(null);
+    }
+  };
+
+  const handleDeleteTodo = async (id: number) => {
+    try {
+      setIdsProccesing([id]);
+      await deleteTodo(id);
+
+      setTodos(currentTodos => currentTodos.filter(todo => todo.id !== id));
+    } catch {
+      setErrorMessage('Unable to delete a todo');
+    } finally {
+      setIdsProccesing([]);
+    }
+  };
+
+  const handleEditTodo = async (id: number, data: Partial<Todo>) => {
+    try {
+      setIdsProccesing([id]);
+      const editedTodo = await patchTodo(id, data);
+
+      setTodos(currentTodos =>
+        currentTodos.map(todo => {
+          if (todo.id === id) {
+            return editedTodo;
+          }
+
+          return todo;
+        }),
+      );
+    } catch {
+      setErrorMessage('Unable to update a todo');
+      throw new Error('Unable to update a todo');
+    } finally {
+      setIdsProccesing([]);
+    }
+  };
+
+  const clearCompletedTodos = async () => {
+    const filteredTodos = todos.filter(todo => todo.completed);
+    const completedIds = filteredTodos.map(todo => todo.id);
+
+    setIdsProccesing(completedIds);
+
+    try {
+      const deleteCallback = async (todo: Todo) => {
+        try {
+          await deleteTodo(todo.id);
+
+          return { id: todo.id, status: 'resolved' };
+        } catch {
+          setErrorMessage('Unable to delete a todo');
+
+          return { id: todo.id, status: 'rejected' };
+        } finally {
+          setIdsProccesing([]);
+        }
+      };
+
+      const res = await Promise.allSettled(filteredTodos.map(deleteCallback));
+
+      const resolvedIds = res.reduce(
+        (acc, item) => {
+          if (item.status === 'rejected') {
+            return acc;
+          }
+
+          if (item.value.status === 'resolved') {
+            return { ...acc, [item.value.id]: item.value.id };
+          }
+
+          return acc;
+        },
+        {} as Record<number, number>,
+      );
+
+      setTodos(currentTodos =>
+        currentTodos.filter(todo => {
+          if (resolvedIds[todo.id] && todo.completed) {
+            return false;
+          }
+
+          return true;
+        }),
+      );
+    } catch {
+      setErrorMessage('Unable to clear completed todos');
+    }
+  };
+
+  const filterTodos = useMemo(() => {
+    let filteredTodos = todos;
+
+    switch (filter) {
+      case Filter.Active:
+        filteredTodos = todos.filter(todo => !todo.completed);
+        break;
+      case Filter.Completed:
+        filteredTodos = todos.filter(todo => todo.completed);
+        break;
+      default:
+        break;
+    }
+
+    return filteredTodos;
+  }, [todos, filter]);
+
+  const todosCount = useMemo(() => {
+    const active = todos.filter(({ completed }) => !completed).length;
+    const completed = todos.length - active;
+
+    return {
+      active,
+      completed,
+    };
+  }, [todos]);
+
+  const handleToggleAll = async () => {
+    if (todosCount.completed === todos.length) {
+      try {
+        setIdsProccesing(todos.map(todo => todo.id));
+
+        const updatedTodos = await Promise.all(
+          todos.map(todo => patchTodo(todo.id, { completed: false })),
+        );
+
+        setTodos(updatedTodos);
+      } catch {
+        setErrorMessage('Unable to update todos');
+      } finally {
+        setIdsProccesing([]);
+      }
+
+      return;
+    }
+
+    const filteredTodos = todos.filter(todo => !todo.completed);
+    const activeIds = filteredTodos.map(todo => todo.id);
+
+    setIdsProccesing(activeIds);
+
+    try {
+      await Promise.all(
+        filteredTodos.map(todo => patchTodo(todo.id, { completed: true })),
+      );
+
+      setTodos(currentTodos =>
+        currentTodos.map(todo => {
+          if (!todo.completed) {
+            return { ...todo, completed: true };
+          }
+
+          return todo;
+        }),
+      );
+    } catch {
+      setErrorMessage('Unable to update todos');
+    } finally {
+      setIdsProccesing([]);
+    }
+  };
+
+  useEffect(() => {
+    getTodos()
+      .then(setTodos)
+      .catch(() => setErrorMessage('Unable to load todos'));
+  }, []);
+
+  useEffect(() => {
+    ref.current?.focus();
+  }, [todos.length, tempTodoTitle]);
+
   if (!USER_ID) {
     return <UserWarning />;
   }
 
   return (
-    <section className="section container">
-      <p className="title is-4">
-        Copy all you need from the prev task:
-        <br />
-        <a href="https://github.com/mate-academy/react_todo-app-add-and-delete#react-todo-app-add-and-delete">
-          React Todo App - Add and Delete
-        </a>
-      </p>
+    <div className="todoapp">
+      <h1 className="todoapp__title">todos</h1>
 
-      <p className="subtitle">Styles are already copied</p>
-    </section>
+      <div className="todoapp__content">
+        <Header
+          onAdd={handleAddTodo}
+          onToggleAll={handleToggleAll}
+          inputRef={ref}
+          todosCount={todosCount}
+        />
+
+        <List
+          onDelete={handleDeleteTodo}
+          onEdit={handleEditTodo}
+          todos={filterTodos}
+          tempTodoTitle={tempTodoTitle}
+          idsProccesing={idsProccesing}
+        />
+
+        {todos.length > 0 && (
+          <Footer
+            onFilter={setFilter}
+            onClear={clearCompletedTodos}
+            todosCount={todosCount}
+            selectedFilter={filter}
+          />
+        )}
+      </div>
+
+      <ErrorMessage
+        message={errorMessage}
+        onClose={() => setErrorMessage('')}
+      />
+    </div>
   );
 };

--- a/src/api/todos.ts
+++ b/src/api/todos.ts
@@ -1,0 +1,20 @@
+import { Todo } from '../types/Todo';
+import { client } from '../utils/fetchClient';
+
+export const USER_ID = 10215;
+
+export const getTodos = () => {
+  return client.get<Todo[]>(`/todos?userId=${USER_ID}`);
+};
+
+export const createTodo = (todo: Omit<Todo, 'id'>) => {
+  return client.post<Todo>('/todos', todo);
+};
+
+export const deleteTodo = (id: number) => {
+  return client.delete(`/todos/${id}`);
+};
+
+export const patchTodo = (id: number, data: Partial<Todo>) => {
+  return client.patch<Todo>(`/todos/${id}`, data);
+};

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -1,0 +1,28 @@
+import { FC, useEffect } from 'react';
+import cn from 'classnames';
+
+interface Props {
+  message: string;
+  onClose: () => void;
+}
+
+export const Error: FC<Props> = ({ message, onClose }) => {
+  useEffect(() => {
+    const timeout = setTimeout(onClose, 3000);
+
+    return () => clearTimeout(timeout);
+  }, [message, onClose]);
+
+  return (
+    <div
+      data-cy="ErrorNotification"
+      className={cn('notification is-danger is-light has-text-weight-normal', {
+        hidden: !message,
+      })}
+    >
+      <button data-cy="HideErrorButton" type="button" className="delete" />
+      {/* show only one message at a time */}
+      {message}
+    </div>
+  );
+};

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,56 @@
+import { FC } from 'react';
+import cn from 'classnames';
+import { Filter } from '../types/Filter';
+
+interface Props {
+  onFilter: (filter: Filter) => void;
+  onClear: () => void;
+  selectedFilter: Filter;
+  todosCount: {
+    active: number;
+    completed: number;
+  };
+}
+
+export const Footer: FC<Props> = ({
+  onFilter,
+  onClear,
+  todosCount,
+  selectedFilter,
+}) => {
+  const filters = [Filter.All, Filter.Active, Filter.Completed];
+
+  return (
+    <footer className="todoapp__footer" data-cy="Footer">
+      <span className="todo-count" data-cy="TodosCounter">
+        {todosCount.active} items left
+      </span>
+
+      <nav className="filter" data-cy="Filter">
+        {filters.map(filter => (
+          <a
+            key={filter}
+            href={`#${filter}`}
+            className={cn('filter__link', {
+              selected: filter === selectedFilter,
+            })}
+            data-cy={`FilterLink${filter}`}
+            onClick={() => onFilter(filter)}
+          >
+            {filter}
+          </a>
+        ))}
+      </nav>
+
+      <button
+        type="button"
+        className="todoapp__clear-completed"
+        data-cy="ClearCompletedButton"
+        disabled={todosCount.completed === 0}
+        onClick={onClear}
+      >
+        Clear completed
+      </button>
+    </footer>
+  );
+};

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,70 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+/* eslint-disable jsx-a11y/control-has-associated-label */
+import { FC, useEffect, useState } from 'react';
+import cn from 'classnames';
+
+interface Props {
+  onAdd: (title: string) => Promise<void>;
+  onToggleAll: () => Promise<void>;
+  inputRef: React.MutableRefObject<HTMLInputElement | null>;
+  todosCount: { active: number; completed: number };
+}
+
+export const Header: FC<Props> = ({
+  onAdd,
+  onToggleAll,
+  inputRef,
+  todosCount,
+}) => {
+  const [title, setTitle] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    try {
+      setLoading(true);
+      await onAdd(title);
+      setTitle('');
+    } catch {
+      // eslint-disable-next-line no-console
+      console.log('Error adding todo');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [inputRef, loading]);
+
+  return (
+    <header className="todoapp__header">
+      {(todosCount.active > 0 || todosCount.completed > 0) && (
+        <button
+          type="button"
+          className={cn('todoapp__toggle-all', {
+            active: todosCount.active === 0,
+          })}
+          data-cy="ToggleAllButton"
+          onClick={onToggleAll}
+        />
+      )}
+
+      <form onSubmit={handleSubmit}>
+        <input
+          ref={inputRef}
+          data-cy="NewTodoField"
+          type="text"
+          value={title}
+          disabled={loading}
+          onChange={({ target }) => setTitle(target.value)}
+          className="todoapp__new-todo"
+          placeholder="What needs to be done?"
+        />
+      </form>
+    </header>
+  );
+};

--- a/src/components/List.tsx
+++ b/src/components/List.tsx
@@ -1,0 +1,38 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+/* eslint-disable jsx-a11y/control-has-associated-label */
+import { FC } from 'react';
+import { Todo as TodoType } from '../types/Todo';
+import { Todo } from './Todo';
+import { TempTodo } from './TempTodo';
+
+interface Props {
+  onDelete: (id: number) => Promise<void>;
+  onEdit: (id: number, data: Partial<TodoType>) => Promise<void>;
+  todos: TodoType[];
+  tempTodoTitle: string | null;
+  idsProccesing: number[];
+}
+
+export const List: FC<Props> = ({
+  todos,
+  tempTodoTitle,
+  onDelete,
+  onEdit,
+  idsProccesing,
+}) => {
+  return (
+    <section className="todoapp__main" data-cy="TodoList">
+      {todos.map(todo => (
+        <Todo
+          key={todo.id}
+          todo={todo}
+          onDelete={onDelete}
+          onEdit={onEdit}
+          idsProccesing={idsProccesing}
+        />
+      ))}
+
+      {tempTodoTitle && <TempTodo title={tempTodoTitle} />}
+    </section>
+  );
+};

--- a/src/components/TempTodo.tsx
+++ b/src/components/TempTodo.tsx
@@ -1,0 +1,26 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+/* eslint-disable jsx-a11y/control-has-associated-label */
+import { FC } from 'react';
+
+interface Props {
+  title: string;
+}
+
+export const TempTodo: FC<Props> = ({ title }) => {
+  return (
+    <div data-cy="Todo" className="todo">
+      <label className="todo__status-label">
+        <input data-cy="TodoStatus" type="checkbox" className="todo__status" />
+      </label>
+
+      <span data-cy="TodoTitle" className="todo__title">
+        {title}
+      </span>
+
+      <div data-cy="TodoLoader" className="modal overlay is-active">
+        <div className="modal-background has-background-white-ter" />
+        <div className="loader" />
+      </div>
+    </div>
+  );
+};

--- a/src/components/Todo.tsx
+++ b/src/components/Todo.tsx
@@ -1,0 +1,84 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+/* eslint-disable jsx-a11y/control-has-associated-label */
+import { FC } from 'react';
+import cn from 'classnames';
+import { Todo as TodoType } from '../types/Todo';
+import { TodoForm } from './TodoForm';
+import { useTodo } from '../hooks/useTodo';
+
+interface Props {
+  todo: TodoType;
+  idsProccesing: number[];
+  onDelete: (id: number) => Promise<void>;
+  onEdit: (id: number, data: Partial<TodoType>) => Promise<void>;
+}
+
+export const Todo: FC<Props> = ({ todo, onDelete, onEdit, idsProccesing }) => {
+  const {
+    handleCompleted,
+    handleDelete,
+    handleTitleEdit,
+    setIsEditing,
+    inputRef,
+    isEditing,
+  } = useTodo({ onDelete, onEdit, todo });
+
+  return (
+    <div
+      data-cy="Todo"
+      className={cn('todo', {
+        completed: todo.completed,
+      })}
+      key={todo.id}
+    >
+      <label className="todo__status-label">
+        <input
+          data-cy="TodoStatus"
+          type="checkbox"
+          className="todo__status"
+          onChange={() => handleCompleted(!todo.completed)}
+          checked={todo.completed}
+        />
+      </label>
+
+      {isEditing ? (
+        <div onKeyUp={({ key }) => key === 'Escape' && setIsEditing(false)}>
+          <TodoForm
+            title={todo.title}
+            onSubmit={handleTitleEdit}
+            inputRef={inputRef}
+          />
+        </div>
+      ) : (
+        <span
+          data-cy="TodoTitle"
+          className="todo__title"
+          onDoubleClick={() => setIsEditing(true)}
+        >
+          {todo.title}
+        </span>
+      )}
+
+      {!isEditing && (
+        <button
+          type="button"
+          className="todo__remove"
+          data-cy="TodoDelete"
+          onClick={handleDelete}
+        >
+          ×
+        </button>
+      )}
+
+      <div
+        data-cy="TodoLoader"
+        className={cn('modal overlay', {
+          'is-active': idsProccesing.includes(todo.id),
+        })}
+      >
+        <div className="modal-background has-background-white-ter" />
+        <div className="loader" />
+      </div>
+    </div>
+  );
+};

--- a/src/components/TodoForm.tsx
+++ b/src/components/TodoForm.tsx
@@ -1,0 +1,38 @@
+import { FC, useEffect, useState } from 'react';
+
+interface Props {
+  title: string;
+  onSubmit: (title: string) => void;
+  inputRef: React.MutableRefObject<HTMLInputElement | null>;
+}
+
+export const TodoForm: FC<Props> = ({ title, onSubmit, inputRef }) => {
+  const [value, setValue] = useState(title);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    onSubmit(value);
+  };
+
+  useEffect(() => {
+    if (inputRef?.current) {
+      inputRef.current?.focus();
+    }
+  }, [inputRef]);
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <input
+        ref={inputRef}
+        data-cy="TodoTitleField"
+        type="text"
+        className="todo__title-field"
+        placeholder="Empty todo will be deleted"
+        value={value}
+        onChange={({ target }) => setValue(target.value)}
+        onBlur={() => onSubmit(value)}
+      />
+    </form>
+  );
+};

--- a/src/hooks/useTodo.ts
+++ b/src/hooks/useTodo.ts
@@ -1,0 +1,66 @@
+import { useRef, useState } from 'react';
+import { Todo } from '../types/Todo';
+
+type InputHook = {
+  todo: Todo;
+  onDelete: (id: number) => Promise<void>;
+  onEdit: (id: number, data: Partial<Todo>) => Promise<void>;
+};
+
+export const useTodo = (input: InputHook) => {
+  const { onDelete, onEdit, todo } = input;
+
+  const [isEditing, setIsEditing] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleDelete = async () => {
+    try {
+      await onDelete(todo.id);
+    } catch {
+      // eslint-disable-next-line no-console
+      console.log('Error deleting todo');
+    }
+  };
+
+  const handleCompleted = async (completed: boolean) => {
+    try {
+      await onEdit(todo.id, { completed });
+    } catch {
+      // eslint-disable-next-line no-console
+      console.log('Error editing todo');
+    }
+  };
+
+  const handleTitleEdit = async (title: string) => {
+    const formattedTitle = title.trim();
+
+    if (!formattedTitle) {
+      return handleDelete();
+    }
+
+    if (title === todo.title) {
+      setIsEditing(false);
+
+      return;
+    }
+
+    try {
+      await onEdit(todo.id, { title: formattedTitle });
+
+      setIsEditing(false);
+    } catch {
+      // eslint-disable-next-line no-console
+      inputRef.current?.focus();
+    }
+  };
+
+  return {
+    isEditing,
+    inputRef,
+    handleDelete,
+    handleCompleted,
+    handleTitleEdit,
+    setIsEditing,
+  };
+};

--- a/src/types/Filter.tsx
+++ b/src/types/Filter.tsx
@@ -1,0 +1,5 @@
+export enum Filter {
+  All = 'All',
+  Active = 'Active',
+  Completed = 'Completed',
+}

--- a/src/types/Todo.ts
+++ b/src/types/Todo.ts
@@ -1,0 +1,6 @@
+export interface Todo {
+  id: number;
+  userId: number;
+  title: string;
+  completed: boolean;
+}

--- a/src/utils/fetchClient.ts
+++ b/src/utils/fetchClient.ts
@@ -1,0 +1,46 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const BASE_URL = 'https://mate.academy/students-api';
+
+// returns a promise resolved after a given delay
+function wait(delay: number) {
+  return new Promise(resolve => {
+    setTimeout(resolve, delay);
+  });
+}
+
+// To have autocompletion and avoid mistypes
+type RequestMethod = 'GET' | 'POST' | 'PATCH' | 'DELETE';
+
+function request<T>(
+  url: string,
+  method: RequestMethod = 'GET',
+  data: any = null, // we can send any data to the server
+): Promise<T> {
+  const options: RequestInit = { method };
+
+  if (data) {
+    // We add body and Content-Type only for the requests with data
+    options.body = JSON.stringify(data);
+    options.headers = {
+      'Content-Type': 'application/json; charset=UTF-8',
+    };
+  }
+
+  // DON'T change the delay it is required for tests
+  return wait(100)
+    .then(() => fetch(BASE_URL + url, options))
+    .then(response => {
+      if (!response.ok) {
+        throw new Error();
+      }
+
+      return response.json();
+    });
+}
+
+export const client = {
+  get: <T>(url: string) => request<T>(url),
+  post: <T>(url: string, data: any) => request<T>(url, 'POST', data),
+  patch: <T>(url: string, data: any) => request<T>(url, 'PATCH', data),
+  delete: (url: string) => request(url, 'DELETE'),
+};


### PR DESCRIPTION
https://akryto.github.io/react_todo-app-with-api/
Implement the ability to edit a todo title on double click:

- show the edit form instead of the title and remove button;
- saves changes on the form submit (just press `Enter`);
- save changes when the field loses focus (`onBlur`);
- if the new title is the same as the old one just cancel editing;
- cancel editing on `Esс` key `keyup` event;
- if the new title is empty delete the todo the same way the `x` button does it;
- if the title was changed show the loader while waiting for the API response;
- update the todo title on success;
- show `Unable to update a todo` in case of API error;
- or the deletion error message if we tried to delete the todo.